### PR TITLE
Limit repaint rate to 30 fps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.gradle
 /build
 /.idea
+/dist

--- a/src/main/java/spacemonger1/controller/FolderView.java
+++ b/src/main/java/spacemonger1/controller/FolderView.java
@@ -708,16 +708,27 @@ public class FolderView {
 
         repaint();
     }
+
     private void onMouseMove(MouseEvent e) {
         Point point = e.getPoint();
         DisplayFolder cur = GetDisplayFolderFromPoint(point);
 
         if (appCommands.settings().rollover_box()) {
             hightlightPathPoint = point;
+
+            // Swing can produce hundreds mouse events per sec, lets limit repaint rate to 30 fps.
+            if (repaintLimitTimer == null) {
+                repaintLimitTimer = new Timer(1000 / 30, _ -> {
+                    repaint();
+                    repaintLimitTimer = null;
+                });
+                repaintLimitTimer.setRepeats(false);
+                repaintLimitTimer.start();
+            }
         } else {
             hightlightPathPoint = null;
         }
-        repaint();
+
         if (appCommands.settings().show_info_tips()) {
             if (cur == null) {
                 m_infotipwnd.enableWindow(false);
@@ -1340,6 +1351,9 @@ public class FolderView {
     private Rectangle animEnd;
     private int animStep = -1; // -1 = inactive, 0–15 = active
     private Runnable animOnComplete;
+
+    // timer to limit repaint rate
+    private Timer repaintLimitTimer = null;
 
     private final Font minifont = new Font("SansSerif", Font.PLAIN, 9);
     private final AppCommands appCommands;

--- a/src/main/java/spacemonger1/service/Lang.java
+++ b/src/main/java/spacemonger1/service/Lang.java
@@ -50,8 +50,8 @@ public class Lang {
 
     public static Lang load(String langCode) {
         Properties props = new Properties();
-        String resourceName = "/lang_" + langCode + ".properties";
-        try (InputStream is = Lang.class.getResourceAsStream(resourceName)) {
+        String resourceName = "lang_" + langCode + ".properties";
+        try (InputStream is = Lang.class.getClassLoader().getResourceAsStream(resourceName)) {
             if (is == null) {
                 throw new RuntimeException("Language file not found: " + resourceName);
             }

--- a/src/main/java/spacemonger1/service/LangService.java
+++ b/src/main/java/spacemonger1/service/LangService.java
@@ -12,7 +12,7 @@ public class LangService {
 
     public LangService() {
         Properties props = new Properties();
-        try (InputStream is = LangService.class.getResourceAsStream("/spacemonger1.properties")) {
+        try (InputStream is = LangService.class.getClassLoader().getResourceAsStream("spacemonger1.properties")) {
             if (is == null) {
                 throw new IllegalArgumentException("Resource not found: /spacemonger1.properties");
             }


### PR DESCRIPTION
Problem
Due to rollover box feature, we need to repaint the screen every time mouse moves, producing hundreds of repaints per second.

Solution
Do repaint only when rollover box is enabled. Limit repaint rate to 30 repaints per second.

Fixes #2